### PR TITLE
Remove export macro from namespace - msvc does not handle that. 

### DIFF
--- a/vilga/include/vilga/detail/backend.hpp
+++ b/vilga/include/vilga/detail/backend.hpp
@@ -5,7 +5,7 @@
 #include <memory>
 #include <vilga/detail/macros.hpp>
 
-namespace vilga_detail VILGA_EXPORT {
+namespace vilga_detail {
 
 class data;
 struct vilga_backend_initializer;
@@ -13,7 +13,7 @@ struct vilga_backend_initializer;
 /**
  * Single entry point which routes data into destinations.
  */
-class backend {
+class VILGA_EXPORT backend {
 private:
   backend();
   ~backend();
@@ -31,7 +31,7 @@ private:
 extern backend& backend_instance;
 
 /// static backend initializer for every translation unit
-static struct vilga_backend_initializer {
+static struct VILGA_EXPORT vilga_backend_initializer {
   vilga_backend_initializer() noexcept;
   ~vilga_backend_initializer() noexcept;
 } vilga_backend_init;

--- a/vilga/include/vilga/detail/backend_config.hpp
+++ b/vilga/include/vilga/detail/backend_config.hpp
@@ -5,7 +5,7 @@
 #include <string>
 #include <vilga/detail/macros.hpp>
 
-namespace vilga_detail VILGA_EXPORT {
+namespace vilga_detail {
 
 struct backend_config {
   std::string zmq_protocol; // FIXME: leaking implementation detail.

--- a/vilga/include/vilga/detail/data.hpp
+++ b/vilga/include/vilga/detail/data.hpp
@@ -6,7 +6,7 @@
 #include <string>
 #include <vilga/detail/macros.hpp>
 
-namespace vilga_detail VILGA_EXPORT {
+namespace vilga_detail {
 
 class memory_block_t {
 public:

--- a/vilga/include/vilga/detail/macros.hpp
+++ b/vilga/include/vilga/detail/macros.hpp
@@ -5,7 +5,7 @@
 // This file contains minimal, required suite of macros for API tagging in more cross-compile manner
 
 #if (defined WIN32 || defined _WIN32 || defined WINCE || defined __CYGWIN__)
-  #ifdef VILGA_EXPORTS // FIXME: make this work
+  #ifdef vilga_EXPORTS // FIXME: make this work
       #define VILGA_EXPORT __declspec(dllexport)
    #else
       #define VILGA_EXPORT __declspec(dllimport)

--- a/vilga/include/vilga/detail/named_values.hpp
+++ b/vilga/include/vilga/detail/named_values.hpp
@@ -7,14 +7,14 @@
 #include <type_traits>
 #include <utility>
 
-namespace vilga_detail VILGA_EXPORT {
+namespace vilga_detail {
 
 /**
  * Implements support for basic arithmetic types for named values
  * @tparam T serializable arithmetic type
  */
 template<class T, typename = typename std::enable_if<std::is_arithmetic<T>::value, T>::type>
-class spell_named_value : public portal_spell {
+class VILGA_EXPORT spell_named_value : public portal_spell {
 public:
   spell_named_value(std::string name, const T& object) noexcept : ref_(object), name_(std::move(name)) {
   }

--- a/vilga/include/vilga/detail/portal_spell.hpp
+++ b/vilga/include/vilga/detail/portal_spell.hpp
@@ -16,7 +16,7 @@ class data;
 /**
  * This class is an interface which allows to send any data by portal
  */
-class portal_spell {
+class VILGA_EXPORT portal_spell {
 public:
   template<class>
   friend class vilga::portal;

--- a/vilga/include/vilga/portal.hpp
+++ b/vilga/include/vilga/portal.hpp
@@ -7,7 +7,7 @@
 #include <vilga/detail/data.hpp>
 #include <vilga/detail/portal_spell.hpp>
 
-namespace vilga VILGA_EXPORT {
+namespace vilga {
 
 /**
  * Stores some global settings for the portal
@@ -23,7 +23,7 @@ struct portal_settings {
  * Main portal class which provides interface for sending data, similar to logger.
  */
 template <class Destination>
-class portal {
+class VILGA_EXPORT portal {
 public:
   explicit portal(portal_settings settings) : portal_settings_(settings) {
   }

--- a/vilga/src/detail/backend.cpp
+++ b/vilga/src/detail/backend.cpp
@@ -4,7 +4,6 @@
 #include <type_traits>
 #include <vilga_impl/backend.hpp>
 #include <vilga/detail/data.hpp>
-#include <iostream>
 
 namespace vilga_detail {
 
@@ -19,14 +18,10 @@ static typename std::aligned_storage<sizeof(backend), alignof(backend)>::type ba
 backend& backend_instance = reinterpret_cast<backend&>(backend_memory);
 
 backend::backend() {
-  // this is a place when it would be possible to inject alternative implementation
-  std::cout << "backend created" << std::endl;
   impl_ = std::make_unique<backend::impl>();
 }
 
-backend::~backend() {
-  std::cout << "backend destroyed" << std::endl;
-}
+backend::~backend() = default;
 
 void backend::consume(data&& data) {
   impl_->consume(std::move(data));


### PR DESCRIPTION
Remove also debug prints